### PR TITLE
Now the webpage only asks for your metamask login when you click to buy it

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1838,6 +1838,11 @@
       "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
     },
+    "aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+    },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -6161,6 +6166,22 @@
         }
       }
     },
+    "eth-ens-namehash": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+      "requires": {
+        "idna-uts46-hx": "^2.3.1",
+        "js-sha3": "^0.5.7"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
     "eth-lib": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
@@ -6227,6 +6248,65 @@
         "rlp": "^2.0.0",
         "safe-buffer": "^5.1.1",
         "secp256k1": "^3.0.1"
+      }
+    },
+    "ethers": {
+      "version": "4.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.1.tgz",
+      "integrity": "sha512-SoYhktEbLxf+fiux5SfCEwdzWENMvgIbMZD90I62s4GZD9nEjgEWy8ZboI3hck193Vs0bDoTohDISx84f2H2tw==",
+      "requires": {
+        "@types/node": "^10.3.2",
+        "aes-js": "3.0.0",
+        "bn.js": "^4.4.0",
+        "elliptic": "6.3.3",
+        "hash.js": "1.1.3",
+        "js-sha3": "0.5.7",
+        "scrypt-js": "2.0.3",
+        "setimmediate": "1.0.4",
+        "uuid": "2.0.1",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
+          "integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg=="
+        },
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        }
       }
     },
     "ethjs-unit": {
@@ -7617,6 +7697,21 @@
       "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
       "requires": {
         "harmony-reflect": "^1.4.6"
+      }
+    },
+    "idna-uts46-hx": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
       }
     },
     "ieee754": {
@@ -13007,6 +13102,11 @@
         "nan": "^2.0.8"
       }
     },
+    "scrypt-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+      "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+    },
     "scrypt.js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
@@ -14401,6 +14501,312 @@
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
       "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q=="
     },
+    "truffle-hdwallet-provider": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/truffle-hdwallet-provider/-/truffle-hdwallet-provider-1.0.10.tgz",
+      "integrity": "sha512-nP66WEuboye8lZblXhVaoCieubBxcCqQFpR8k1CsFq016iWDiPypPiqY8X4jdSTKNOJ8mfa4yOmQr9cGt20bzQ==",
+      "requires": {
+        "any-promise": "^1.3.0",
+        "bindings": "^1.3.1",
+        "web3": "1.0.0-beta.37",
+        "websocket": "^1.0.28"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "eventemitter3": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
+          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
+          "integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
+          "requires": {
+            "web3-bzz": "1.0.0-beta.37",
+            "web3-core": "1.0.0-beta.37",
+            "web3-eth": "1.0.0-beta.37",
+            "web3-eth-personal": "1.0.0-beta.37",
+            "web3-net": "1.0.0-beta.37",
+            "web3-shh": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.37.tgz",
+          "integrity": "sha512-E+dho49Nsm/QpQvYWOF35YDsQrMvLB19AApENxhlQsu6HpWQt534DQul0t3Y/aAh8rlKD6Kanxt8LhHDG3vejQ==",
+          "requires": {
+            "got": "7.1.0",
+            "swarm-js": "0.1.37",
+            "underscore": "1.8.3"
+          }
+        },
+        "web3-core": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.37.tgz",
+          "integrity": "sha512-cIwEqCj7OJyefQNauI0HOgW4sSaOQ98V99H2/HEIlnCZylsDzfw7gtQUdwnRFiIyIxjbWy3iWsjwDPoXNPZBYg==",
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.37",
+            "web3-core-method": "1.0.0-beta.37",
+            "web3-core-requestmanager": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.37.tgz",
+          "integrity": "sha512-efaLOzN28RMnbugnyelgLwPWWaSwElQzcAJ/x3PZu+uPloM/lE5x0YuBKvIh7/PoSMlHqtRWj1B8CpuQOUQ5Ew==",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-eth-iban": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.37.tgz",
+          "integrity": "sha512-pKWFUeqnVmzx3VrZg+CseSdrl/Yrk2ioid/HzolNXZE6zdoITZL0uRjnsbqXGEzgRRd1Oe/pFndpTlRsnxXloA==",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.37",
+            "web3-core-promievent": "1.0.0-beta.37",
+            "web3-core-subscriptions": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.37.tgz",
+          "integrity": "sha512-GTF2r1lP8nJBeA5Gxq5yZpJy9l8Fb9CXGZPfF8jHvaRdQHtm2Z+NDhqYmF833lcdkokRSyfPcXlz1mlWeClFpg==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "1.1.1"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.37.tgz",
+          "integrity": "sha512-66VUqye5BGp1Zz1r8psCxdNH+GtTjaFwroum2Osx+wbC5oRjAiXkkadiitf6wRb+edodjEMPn49u7B6WGNuewQ==",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.37",
+            "web3-providers-http": "1.0.0-beta.37",
+            "web3-providers-ipc": "1.0.0-beta.37",
+            "web3-providers-ws": "1.0.0-beta.37"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.37.tgz",
+          "integrity": "sha512-FdXl8so9kwkRRWziuCSpFsAuAdg9KvpXa1fQlT16uoGcYYfxwFO/nkwyBGQzkZt7emShI2IRugcazyPCZDwkOA==",
+          "requires": {
+            "eventemitter3": "1.1.1",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.37"
+          }
+        },
+        "web3-eth": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.37.tgz",
+          "integrity": "sha512-Eb3aGtkz3G9q+Z9DKgSQNbn/u8RtcZQQ0R4sW9hy5KK47GoT6vab5c6DiD3QWzI0BzitHzR5Ji+3VHf/hPUGgw==",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.37",
+            "web3-core-helpers": "1.0.0-beta.37",
+            "web3-core-method": "1.0.0-beta.37",
+            "web3-core-subscriptions": "1.0.0-beta.37",
+            "web3-eth-abi": "1.0.0-beta.37",
+            "web3-eth-accounts": "1.0.0-beta.37",
+            "web3-eth-contract": "1.0.0-beta.37",
+            "web3-eth-ens": "1.0.0-beta.37",
+            "web3-eth-iban": "1.0.0-beta.37",
+            "web3-eth-personal": "1.0.0-beta.37",
+            "web3-net": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.37.tgz",
+          "integrity": "sha512-g9DKZGM2OqwKp/tX3W/yihcj7mQCtJ6CXyZXEIZfuDyRBED/iSEIFfieDOd+yo16sokLMig6FG7ADhhu+19hdA==",
+          "requires": {
+            "ethers": "4.0.0-beta.1",
+            "underscore": "1.8.3",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.37.tgz",
+          "integrity": "sha512-uvbHL62/zwo4GDmwKdqH9c/EgYd8QVnAfpVw8D3epSISpgbONNY7Hr4MRMSd/CqAP12l2Ls9JVQGLhhC83bW6g==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scrypt.js": "0.2.0",
+            "underscore": "1.8.3",
+            "uuid": "2.0.1",
+            "web3-core": "1.0.0-beta.37",
+            "web3-core-helpers": "1.0.0-beta.37",
+            "web3-core-method": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.37.tgz",
+          "integrity": "sha512-h1B3A8Z/C7BlnTCHkrWbXZQTViDxfR12lKMeTkT8Sqj5phFmxrBlPE4ORy4lf1Dk5b23mZYE0r/IRACx4ThCrQ==",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.37",
+            "web3-core-helpers": "1.0.0-beta.37",
+            "web3-core-method": "1.0.0-beta.37",
+            "web3-core-promievent": "1.0.0-beta.37",
+            "web3-core-subscriptions": "1.0.0-beta.37",
+            "web3-eth-abi": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.37.tgz",
+          "integrity": "sha512-WQRniGJFxH/XCbd7miO6+jnUG+6bvuzfeufPIiOtCbeIC1ypp1kSqER8YVBDrTyinU1xnf1U5v0KBZ2yiWBJxQ==",
+          "requires": {
+            "bn.js": "4.11.6",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.37.tgz",
+          "integrity": "sha512-B4dZpGbD+nGnn48i6nJBqrQ+HB7oDmd+Q3wGRKOsHSK5HRWO/KwYeA7wgwamMAElkut50lIsT9EJl4Apfk3G5Q==",
+          "requires": {
+            "web3-core": "1.0.0-beta.37",
+            "web3-core-helpers": "1.0.0-beta.37",
+            "web3-core-method": "1.0.0-beta.37",
+            "web3-net": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-net": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.37.tgz",
+          "integrity": "sha512-xG/uBtMdDa1UMXw9KjDUgf3fXA/fDEJUYUS0TDn+U9PMgngA+UVECHNNvQTrVVDxEky38V3sahwIDiopNsQdsw==",
+          "requires": {
+            "web3-core": "1.0.0-beta.37",
+            "web3-core-method": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.37.tgz",
+          "integrity": "sha512-FM/1YDB1jtZuTo78habFj7S9tNHoqt0UipdyoQV29b8LkGKZV9Vs3is8L24hzuj1j/tbwkcAH+ewIseHwu0DTg==",
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.37",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.37.tgz",
+          "integrity": "sha512-NdRPRxYMIU0C3u18NI8u4bwbhI9pCg5nRgDGYcmSAx5uOBxiYcQy+hb0WkJRRhBoyIXJmy+s26FoH8904+UnPg==",
+          "requires": {
+            "oboe": "2.1.3",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.37"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.37.tgz",
+          "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.37",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+              "requires": {
+                "debug": "^2.2.0",
+                "nan": "^2.3.3",
+                "typedarray-to-buffer": "^3.1.2",
+                "yaeti": "^0.0.6"
+              }
+            }
+          }
+        },
+        "web3-shh": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.37.tgz",
+          "integrity": "sha512-h5STG/xqZNQWtCLYOu7NiMqwqPea8SfkKQUPUFxXKIPVCFVKpHuQEwW1qcPQRJMLhlQIv17xuoUe1A+RzDNbrw==",
+          "requires": {
+            "web3-core": "1.0.0-beta.37",
+            "web3-core-method": "1.0.0-beta.37",
+            "web3-core-subscriptions": "1.0.0-beta.37",
+            "web3-net": "1.0.0-beta.37"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
+          "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        },
+        "websocket": {
+          "version": "1.0.28",
+          "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.28.tgz",
+          "integrity": "sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.11.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
+          }
+        }
+      }
+    },
     "ts-pnp": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.2.tgz",
@@ -15148,6 +15554,174 @@
         "web3-utils": "1.0.0-beta.35"
       }
     },
+    "web3-eth-ens": {
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.37.tgz",
+      "integrity": "sha512-dR3UkrVzdRrJhfP57xBPx0CMiVnCcYFvh+u2XMkGydrhHgupSUkjqGr89xry/j1T0BkuN9mikpbyhdCVMXqMbg==",
+      "requires": {
+        "eth-ens-namehash": "2.0.8",
+        "underscore": "1.8.3",
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-promievent": "1.0.0-beta.37",
+        "web3-eth-abi": "1.0.0-beta.37",
+        "web3-eth-contract": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "eventemitter3": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
+          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
+        },
+        "web3-core": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.37.tgz",
+          "integrity": "sha512-cIwEqCj7OJyefQNauI0HOgW4sSaOQ98V99H2/HEIlnCZylsDzfw7gtQUdwnRFiIyIxjbWy3iWsjwDPoXNPZBYg==",
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.37",
+            "web3-core-method": "1.0.0-beta.37",
+            "web3-core-requestmanager": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.37.tgz",
+          "integrity": "sha512-efaLOzN28RMnbugnyelgLwPWWaSwElQzcAJ/x3PZu+uPloM/lE5x0YuBKvIh7/PoSMlHqtRWj1B8CpuQOUQ5Ew==",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-eth-iban": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.37.tgz",
+          "integrity": "sha512-pKWFUeqnVmzx3VrZg+CseSdrl/Yrk2ioid/HzolNXZE6zdoITZL0uRjnsbqXGEzgRRd1Oe/pFndpTlRsnxXloA==",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.37",
+            "web3-core-promievent": "1.0.0-beta.37",
+            "web3-core-subscriptions": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.37.tgz",
+          "integrity": "sha512-GTF2r1lP8nJBeA5Gxq5yZpJy9l8Fb9CXGZPfF8jHvaRdQHtm2Z+NDhqYmF833lcdkokRSyfPcXlz1mlWeClFpg==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "1.1.1"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.37.tgz",
+          "integrity": "sha512-66VUqye5BGp1Zz1r8psCxdNH+GtTjaFwroum2Osx+wbC5oRjAiXkkadiitf6wRb+edodjEMPn49u7B6WGNuewQ==",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.37",
+            "web3-providers-http": "1.0.0-beta.37",
+            "web3-providers-ipc": "1.0.0-beta.37",
+            "web3-providers-ws": "1.0.0-beta.37"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.37.tgz",
+          "integrity": "sha512-FdXl8so9kwkRRWziuCSpFsAuAdg9KvpXa1fQlT16uoGcYYfxwFO/nkwyBGQzkZt7emShI2IRugcazyPCZDwkOA==",
+          "requires": {
+            "eventemitter3": "1.1.1",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.37"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.37.tgz",
+          "integrity": "sha512-g9DKZGM2OqwKp/tX3W/yihcj7mQCtJ6CXyZXEIZfuDyRBED/iSEIFfieDOd+yo16sokLMig6FG7ADhhu+19hdA==",
+          "requires": {
+            "ethers": "4.0.0-beta.1",
+            "underscore": "1.8.3",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.37.tgz",
+          "integrity": "sha512-h1B3A8Z/C7BlnTCHkrWbXZQTViDxfR12lKMeTkT8Sqj5phFmxrBlPE4ORy4lf1Dk5b23mZYE0r/IRACx4ThCrQ==",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.37",
+            "web3-core-helpers": "1.0.0-beta.37",
+            "web3-core-method": "1.0.0-beta.37",
+            "web3-core-promievent": "1.0.0-beta.37",
+            "web3-core-subscriptions": "1.0.0-beta.37",
+            "web3-eth-abi": "1.0.0-beta.37",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.37.tgz",
+          "integrity": "sha512-WQRniGJFxH/XCbd7miO6+jnUG+6bvuzfeufPIiOtCbeIC1ypp1kSqER8YVBDrTyinU1xnf1U5v0KBZ2yiWBJxQ==",
+          "requires": {
+            "bn.js": "4.11.6",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.37.tgz",
+          "integrity": "sha512-FM/1YDB1jtZuTo78habFj7S9tNHoqt0UipdyoQV29b8LkGKZV9Vs3is8L24hzuj1j/tbwkcAH+ewIseHwu0DTg==",
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.37",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.37.tgz",
+          "integrity": "sha512-NdRPRxYMIU0C3u18NI8u4bwbhI9pCg5nRgDGYcmSAx5uOBxiYcQy+hb0WkJRRhBoyIXJmy+s26FoH8904+UnPg==",
+          "requires": {
+            "oboe": "2.1.3",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.37"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.37.tgz",
+          "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.37",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
+          "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          }
+        }
+      }
+    },
     "web3-eth-iban": {
       "version": "1.0.0-beta.35",
       "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.35.tgz",
@@ -15849,6 +16423,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
       "integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw=="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xregexp": {
       "version": "4.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,7 @@
     "rimble-ui": "^0.9.1",
     "styled-components": "^4.2.0",
     "swiper": "^4.5.0",
+    "truffle-hdwallet-provider": "^1.0.10",
     "typescript": "^3.4.5"
   },
   "scripts": {

--- a/app/src/components/BuyModal.tsx
+++ b/app/src/components/BuyModal.tsx
@@ -3,10 +3,8 @@ import PropTypes from "prop-types";
 import Input from '@material-ui/core/Input';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import React, { Component, Fragment } from "react";
-import TokenOverview from "./TokenOverview"
-import OfflineContainer from "./Offline"
 import { Button, Modal, Card, Box, Heading, Text, Flex } from 'rimble-ui'
-import { any } from "prop-types";
+import web3ProvideSwitcher from "../web3ProvideSwitcher"
 
 class BuyModal extends Component<any, any> {
   contracts: any
@@ -111,8 +109,10 @@ class BuyModal extends Component<any, any> {
     }))
   }
 
-  openModal = (e: any) => {
+  openModal = async (e: any) => {
     e.preventDefault()
+    await web3ProvideSwitcher.switchToInjectedWeb3()
+
     this.setState((state: any, props: any) => ({
       isOpen: true
     }))

--- a/app/src/components/BuyModal.tsx
+++ b/app/src/components/BuyModal.tsx
@@ -122,7 +122,7 @@ class BuyModal extends Component<any, any> {
     const valueLabel = "Your Initial Deposit";
     return (
       <React.Fragment>
-        <Button onClick={this.openModal}>Open Modal</Button>
+        <Button onClick={this.openModal}>Buy</Button>
 
         <Modal isOpen={this.state.isOpen}>
           <Card width={'420px'} p={0}>

--- a/app/src/drizzleOptions.tsx
+++ b/app/src/drizzleOptions.tsx
@@ -1,8 +1,10 @@
-import Vitalik from "./contracts/Vitalik.json";
-import ERC721Full from "./contracts/ERC721Full.json";
+import Vitalik from "./contracts/Vitalik.json"
+import ERC721Full from "./contracts/ERC721Full.json"
+import web3ProvideSwitcher from "./web3ProvideSwitcher"
 
 // todo: read env var for fallback
 const fallbackUrl = "wss://mainnet.infura.io/ws/v3/e811479f4c414e219e7673b6671c2aba";
+const switchableWeb3 = web3ProvideSwitcher.createSwitchableWeb3()
 
 interface Options {
   web3: any
@@ -16,6 +18,16 @@ const options: Options = {
     fallback: {
       type: "ws",
       url: fallbackUrl,
+    },
+    customProvider: switchableWeb3,
+    // Repeating this because there seems to be some kind of bug somewhere where web3.web3 is used instead
+    web3: {
+      block: false,
+      fallback: {
+        type: "ws",
+        url: fallbackUrl,
+      },
+      customProvider: switchableWeb3,
     },
   },
   contracts: [

--- a/app/src/nftmetadata.json
+++ b/app/src/nftmetadata.json
@@ -1,5 +1,0 @@
-{
-      "name": "Wild Cards",
-      "description": "The token of endangerd animals",
-      "image": "https://static.thenounproject.com/png/6866-200.png"
-    }

--- a/app/src/react-app-env.d.ts
+++ b/app/src/react-app-env.d.ts
@@ -4,4 +4,5 @@ declare module 'drizzle';
 declare module 'drizzle-react';
 declare module 'drizzle-react-components';
 declare module 'rimble-ui';
+declare module 'truffle-hdwallet-provider';
 

--- a/app/src/web3ProvideSwitcher.ts
+++ b/app/src/web3ProvideSwitcher.ts
@@ -1,0 +1,63 @@
+import HDWalletProvider from "truffle-hdwallet-provider"
+import Web3 from "web3"
+
+const getInjectedWeb3 = async () => {
+
+  if (window.ethereum) {
+    const { ethereum } = window
+    try {
+      await ethereum.enable()
+      return ethereum
+    } catch (error) {
+      // User denied account access...
+      console.log(error)
+    }
+  } else if (typeof (<any>window).web3 !== 'undefined') {
+    console.log('we have the window web3')
+    // Checking if Web3 has been injected by the browser (Mist/MetaMask)
+    // Use Mist/MetaMask's provider.
+    const { currentProvider } = new Web3((<any>window).web3.currentProvider)
+
+    return currentProvider
+  } else {
+    // Out of web3 options; throw.
+    throw new Error('Cannot find injected web3 or valid fallback.')
+  }
+}
+class Web3ProviderSwitcher {
+
+  public static instance: Web3ProviderSwitcher
+  public injectedWeb3: any = null
+  public defaultWeb3: any
+  public usingInjectedWeb3: boolean = false
+
+  constructor() {
+    if (Web3ProviderSwitcher.instance) { return Web3ProviderSwitcher.instance }
+    Web3ProviderSwitcher.instance = this
+
+    this.defaultWeb3 = new HDWalletProvider(process.env.REACT_APP_MNEMONIC, "http://localhost:8545")
+  }
+
+  public async switchToInjectedWeb3() {
+    try {
+      const web3 = await getInjectedWeb3()
+      this.injectedWeb3 = web3
+      this.usingInjectedWeb3 = true
+    } catch (e) {
+      console.log(e)
+    }
+
+    return this.usingInjectedWeb3
+  }
+
+  public createSwitchableWeb3() {
+    const web3RequestHandler = {
+      get: (obj: any, prop: string) =>
+        this.usingInjectedWeb3 ? this.injectedWeb3[prop] : this.defaultWeb3[prop]
+    }
+
+    return new Proxy({}, web3RequestHandler)
+  }
+}
+
+export default new Web3ProviderSwitcher()


### PR DESCRIPTION
This temporarily uses a default 'HDWallet' rather than metamask while metamask isn't logged in.

It uses a 'Proxy' to make the switch. The whole thing is wrapped in a singleton to make it easier to manage. (see here, https://medium.com/dailyjs/how-to-use-javascript-proxies-for-fun-and-profit-365579d4a9f8 and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy , very cool stuff, go JavaScript) 

This is a temporary solution still, there is a much simpler way to do it, but will look at it after the mainnet contract deployment.